### PR TITLE
fix(security): updated npm packages to get from 98 vulns to 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,53 +5,75 @@
     "requires": true,
     "dependencies": {
         "archiver": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
-            "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.0.tgz",
+            "integrity": "sha512-AEWhJz6Yi6hWtN1Sqy/H4sZo/lLMJ/NftXxGaDy/TnOMmmjsRaZc/Ts+U4BsPoBQkuunTN6t8hk7iU9A+HBxLw==",
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.0",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "readable-stream": "2.3.6",
-                "tar-stream": "1.6.1",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^2.1.0",
+                "async": "^3.2.0",
+                "buffer-crc32": "^0.2.1",
+                "readable-stream": "^3.6.0",
+                "readdir-glob": "^1.0.0",
+                "tar-stream": "^2.1.2",
+                "zip-stream": "^4.0.0"
             }
         },
         "archiver-utils": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-            "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+            "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.10",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.2.0",
+                "lazystream": "^1.0.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.difference": "^4.5.0",
+                "lodash.flatten": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.union": "^4.6.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^2.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
             }
         },
         "async": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-            "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-            "requires": {
-                "lodash": "4.17.10"
-            }
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
         },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
+        "base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+        },
         "bl": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-            "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
             "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2"
+                "buffer": "^5.5.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "brace-expansion": {
@@ -59,43 +81,33 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
-        "buffer-alloc": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
-            "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+        "buffer": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
             "requires": {
-                "buffer-alloc-unsafe": "0.1.1",
-                "buffer-fill": "0.1.1"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
             }
-        },
-        "buffer-alloc-unsafe": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
-            "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo="
         },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
         },
-        "buffer-fill": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
-            "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q=="
-        },
         "compress-commons": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
-            "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
+            "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "buffer-crc32": "^0.2.13",
+                "crc32-stream": "^4.0.0",
+                "normalize-path": "^3.0.0",
+                "readable-stream": "^3.6.0"
             }
         },
         "concat-map": {
@@ -109,25 +121,28 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "crc": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
-            "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+            "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+            "requires": {
+                "buffer": "^5.1.0"
+            }
         },
         "crc32-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-            "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
+            "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
             "requires": {
-                "crc": "3.5.0",
-                "readable-stream": "2.3.6"
+                "crc": "^3.4.4",
+                "readable-stream": "^3.4.0"
             }
         },
         "end-of-stream": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "fs-constants": {
@@ -141,36 +156,41 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "glob": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "isarray": {
             "version": "1.0.0",
@@ -182,174 +202,204 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
             }
         },
-        "lodash": {
-            "version": "4.17.10",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+        },
+        "lodash.difference": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+            "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+        },
+        "lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.union": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+            "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
-        },
-        "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "requires": {
-                "minimist": "0.0.8"
-            }
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "normalize-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "requires": {
-                "remove-trailing-separator": "1.1.0"
-            }
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
         },
         "npm": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
-            "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
+            "version": "6.14.8",
+            "resolved": "https://registry.npmjs.org/npm/-/npm-6.14.8.tgz",
+            "integrity": "sha512-HBZVBMYs5blsj94GTeQZel7s9odVuuSUHy1+AlZh7rPVux1os2ashvEGLy/STNK7vUjbrCg5Kq9/GXisJgdf6A==",
             "requires": {
-                "JSONStream": "1.3.4",
-                "abbrev": "1.1.1",
-                "ansicolors": "0.3.2",
-                "ansistyles": "0.1.3",
-                "aproba": "1.2.0",
-                "archy": "1.0.0",
-                "bin-links": "1.1.2",
-                "bluebird": "3.5.1",
-                "byte-size": "4.0.3",
-                "cacache": "11.2.0",
-                "call-limit": "1.1.0",
-                "chownr": "1.0.1",
-                "ci-info": "1.4.0",
-                "cli-columns": "3.1.2",
-                "cli-table3": "0.5.0",
-                "cmd-shim": "2.0.2",
-                "columnify": "1.5.4",
-                "config-chain": "1.1.11",
-                "debuglog": "1.0.1",
-                "detect-indent": "5.0.0",
-                "detect-newline": "2.1.0",
-                "dezalgo": "1.0.3",
-                "editor": "1.0.0",
-                "figgy-pudding": "3.4.1",
-                "find-npm-prefix": "1.0.2",
-                "fs-vacuum": "1.2.10",
-                "fs-write-stream-atomic": "1.0.10",
-                "gentle-fs": "2.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "has-unicode": "2.0.1",
-                "hosted-git-info": "2.7.1",
-                "iferr": "1.0.2",
-                "imurmurhash": "0.1.4",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "ini": "1.3.5",
-                "init-package-json": "1.10.3",
-                "is-cidr": "2.0.6",
-                "json-parse-better-errors": "1.0.2",
-                "lazy-property": "1.0.0",
-                "libcipm": "2.0.2",
-                "libnpmhook": "4.0.1",
-                "libnpx": "10.2.0",
-                "lock-verify": "2.0.2",
-                "lockfile": "1.0.4",
-                "lodash._baseindexof": "3.1.0",
-                "lodash._baseuniq": "4.6.0",
-                "lodash._bindcallback": "3.0.1",
-                "lodash._cacheindexof": "3.0.2",
-                "lodash._createcache": "3.1.2",
-                "lodash._getnative": "3.9.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.restparam": "3.6.1",
-                "lodash.union": "4.6.0",
-                "lodash.uniq": "4.5.0",
-                "lodash.without": "4.4.0",
-                "lru-cache": "4.1.3",
-                "meant": "1.0.1",
-                "mississippi": "3.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "node-gyp": "3.8.0",
-                "nopt": "4.0.1",
-                "normalize-package-data": "2.4.0",
-                "npm-audit-report": "1.3.1",
-                "npm-cache-filename": "1.0.2",
-                "npm-install-checks": "3.0.0",
-                "npm-lifecycle": "2.1.0",
-                "npm-package-arg": "6.1.0",
-                "npm-packlist": "1.1.11",
-                "npm-pick-manifest": "2.1.0",
-                "npm-profile": "3.0.2",
-                "npm-registry-client": "8.6.0",
-                "npm-registry-fetch": "1.1.0",
-                "npm-user-validate": "1.0.0",
-                "npmlog": "4.1.2",
-                "once": "1.4.0",
-                "opener": "1.5.0",
-                "osenv": "0.1.5",
-                "pacote": "8.1.6",
-                "path-is-inside": "1.0.2",
-                "promise-inflight": "1.0.1",
-                "qrcode-terminal": "0.12.0",
-                "query-string": "6.1.0",
-                "qw": "1.0.1",
-                "read": "1.0.7",
-                "read-cmd-shim": "1.0.1",
-                "read-installed": "4.0.3",
-                "read-package-json": "2.0.13",
-                "read-package-tree": "5.2.1",
-                "readable-stream": "2.3.6",
-                "readdir-scoped-modules": "1.0.2",
-                "request": "2.88.0",
-                "retry": "0.12.0",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.2",
-                "semver": "5.5.0",
-                "sha": "2.0.1",
-                "slide": "1.1.6",
-                "sorted-object": "2.0.1",
-                "sorted-union-stream": "2.1.3",
-                "ssri": "6.0.0",
-                "stringify-package": "1.0.0",
-                "tar": "4.4.6",
-                "text-table": "0.2.0",
-                "tiny-relative-date": "1.3.0",
+                "JSONStream": "^1.3.5",
+                "abbrev": "~1.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "^2.0.0",
+                "archy": "~1.0.0",
+                "bin-links": "^1.1.8",
+                "bluebird": "^3.5.5",
+                "byte-size": "^5.0.1",
+                "cacache": "^12.0.3",
+                "call-limit": "^1.1.1",
+                "chownr": "^1.1.4",
+                "ci-info": "^2.0.0",
+                "cli-columns": "^3.1.2",
+                "cli-table3": "^0.5.1",
+                "cmd-shim": "^3.0.3",
+                "columnify": "~1.5.4",
+                "config-chain": "^1.1.12",
+                "debuglog": "*",
+                "detect-indent": "~5.0.0",
+                "detect-newline": "^2.1.0",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "figgy-pudding": "^3.5.1",
+                "find-npm-prefix": "^1.0.2",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "gentle-fs": "^2.3.1",
+                "glob": "^7.1.6",
+                "graceful-fs": "^4.2.4",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "^2.8.8",
+                "iferr": "^1.0.2",
+                "imurmurhash": "*",
+                "infer-owner": "^1.0.4",
+                "inflight": "~1.0.6",
+                "inherits": "^2.0.4",
+                "ini": "^1.3.5",
+                "init-package-json": "^1.10.3",
+                "is-cidr": "^3.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "lazy-property": "~1.0.0",
+                "libcipm": "^4.0.8",
+                "libnpm": "^3.0.1",
+                "libnpmaccess": "^3.0.2",
+                "libnpmhook": "^5.0.3",
+                "libnpmorg": "^1.0.1",
+                "libnpmsearch": "^2.0.2",
+                "libnpmteam": "^1.0.2",
+                "libnpx": "^10.2.4",
+                "lock-verify": "^2.1.0",
+                "lockfile": "^1.0.4",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "lru-cache": "^5.1.1",
+                "meant": "^1.0.2",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.5",
+                "move-concurrently": "^1.0.1",
+                "node-gyp": "^5.1.0",
+                "nopt": "^4.0.3",
+                "normalize-package-data": "^2.5.0",
+                "npm-audit-report": "^1.3.3",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "^3.0.2",
+                "npm-lifecycle": "^3.1.5",
+                "npm-package-arg": "^6.1.1",
+                "npm-packlist": "^1.4.8",
+                "npm-pick-manifest": "^3.0.2",
+                "npm-profile": "^4.0.4",
+                "npm-registry-fetch": "^4.0.7",
+                "npm-user-validate": "~1.0.0",
+                "npmlog": "~4.1.2",
+                "once": "~1.4.0",
+                "opener": "^1.5.1",
+                "osenv": "^0.1.5",
+                "pacote": "^9.5.12",
+                "path-is-inside": "~1.0.2",
+                "promise-inflight": "~1.0.1",
+                "qrcode-terminal": "^0.12.0",
+                "query-string": "^6.8.2",
+                "qw": "~1.0.1",
+                "read": "~1.0.7",
+                "read-cmd-shim": "^1.0.5",
+                "read-installed": "~4.0.3",
+                "read-package-json": "^2.1.1",
+                "read-package-tree": "^5.3.1",
+                "readable-stream": "^3.6.0",
+                "readdir-scoped-modules": "^1.1.0",
+                "request": "^2.88.0",
+                "retry": "^0.12.0",
+                "rimraf": "^2.7.1",
+                "safe-buffer": "^5.1.2",
+                "semver": "^5.7.1",
+                "sha": "^3.0.0",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "ssri": "^6.0.1",
+                "stringify-package": "^1.0.1",
+                "tar": "^4.4.13",
+                "text-table": "~0.2.0",
+                "tiny-relative-date": "^1.3.0",
                 "uid-number": "0.0.6",
-                "umask": "1.1.0",
-                "unique-filename": "1.1.0",
-                "unpipe": "1.0.0",
-                "update-notifier": "2.5.0",
-                "uuid": "3.3.2",
-                "validate-npm-package-license": "3.0.4",
-                "validate-npm-package-name": "3.0.0",
-                "which": "1.3.1",
-                "worker-farm": "1.6.0",
-                "write-file-atomic": "2.3.0"
+                "umask": "~1.1.0",
+                "unique-filename": "^1.1.1",
+                "unpipe": "~1.0.0",
+                "update-notifier": "^2.5.0",
+                "uuid": "^3.3.3",
+                "validate-npm-package-license": "^3.0.4",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "^1.3.1",
+                "worker-farm": "^1.7.0",
+                "write-file-atomic": "^2.4.3"
             },
             "dependencies": {
                 "JSONStream": {
-                    "version": "1.3.4",
+                    "version": "1.3.5",
                     "bundled": true,
                     "requires": {
-                        "jsonparse": "1.3.1",
-                        "through": "2.3.8"
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
                     }
                 },
                 "abbrev": {
@@ -357,34 +407,34 @@
                     "bundled": true
                 },
                 "agent-base": {
-                    "version": "4.2.0",
+                    "version": "4.3.0",
                     "bundled": true,
                     "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                     }
                 },
                 "agentkeepalive": {
-                    "version": "3.4.1",
+                    "version": "3.5.2",
                     "bundled": true,
                     "requires": {
-                        "humanize-ms": "1.2.1"
+                        "humanize-ms": "^1.2.1"
                     }
                 },
                 "ajv": {
                     "version": "5.5.2",
                     "bundled": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "ansi-align": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1"
+                        "string-width": "^2.0.0"
                     }
                 },
                 "ansi-regex": {
@@ -395,7 +445,7 @@
                     "version": "3.2.1",
                     "bundled": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "ansicolors": {
@@ -407,7 +457,7 @@
                     "bundled": true
                 },
                 "aproba": {
-                    "version": "1.2.0",
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "archy": {
@@ -418,8 +468,30 @@
                     "version": "1.1.4",
                     "bundled": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "asap": {
@@ -430,7 +502,7 @@
                     "version": "0.2.4",
                     "bundled": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "~2.1.0"
                     }
                 },
                 "assert-plus": {
@@ -458,58 +530,48 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "bin-links": {
-                    "version": "1.1.2",
+                    "version": "1.1.8",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "cmd-shim": "2.0.2",
-                        "gentle-fs": "2.0.1",
-                        "graceful-fs": "4.1.11",
-                        "write-file-atomic": "2.3.0"
-                    }
-                },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "requires": {
-                        "inherits": "2.0.3"
+                        "bluebird": "^3.5.3",
+                        "cmd-shim": "^3.0.0",
+                        "gentle-fs": "^2.3.0",
+                        "graceful-fs": "^4.1.15",
+                        "npm-normalize-package-bin": "^1.0.0",
+                        "write-file-atomic": "^2.3.0"
                     }
                 },
                 "bluebird": {
-                    "version": "3.5.1",
+                    "version": "3.5.5",
                     "bundled": true
                 },
                 "boxen": {
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "ansi-align": "2.0.0",
-                        "camelcase": "4.1.0",
-                        "chalk": "2.4.1",
-                        "cli-boxes": "1.0.0",
-                        "string-width": "2.1.1",
-                        "term-size": "1.2.0",
-                        "widest-line": "2.0.0"
+                        "ansi-align": "^2.0.0",
+                        "camelcase": "^4.0.0",
+                        "chalk": "^2.0.1",
+                        "cli-boxes": "^1.0.0",
+                        "string-width": "^2.0.0",
+                        "term-size": "^1.2.0",
+                        "widest-line": "^2.0.0"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
                 "buffer-from": {
                     "version": "1.0.0",
-                    "bundled": true
-                },
-                "builtin-modules": {
-                    "version": "1.1.1",
                     "bundled": true
                 },
                 "builtins": {
@@ -521,31 +583,32 @@
                     "bundled": true
                 },
                 "byte-size": {
-                    "version": "4.0.3",
+                    "version": "5.0.1",
                     "bundled": true
                 },
                 "cacache": {
-                    "version": "11.2.0",
+                    "version": "12.0.3",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "chownr": "1.0.1",
-                        "figgy-pudding": "3.4.1",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "lru-cache": "4.1.3",
-                        "mississippi": "3.0.0",
-                        "mkdirp": "0.5.1",
-                        "move-concurrently": "1.0.1",
-                        "promise-inflight": "1.0.1",
-                        "rimraf": "2.6.2",
-                        "ssri": "6.0.0",
-                        "unique-filename": "1.1.0",
-                        "y18n": "4.0.0"
+                        "bluebird": "^3.5.5",
+                        "chownr": "^1.1.1",
+                        "figgy-pudding": "^3.5.1",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.1.15",
+                        "infer-owner": "^1.0.3",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "move-concurrently": "^1.0.1",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^2.6.3",
+                        "ssri": "^6.0.1",
+                        "unique-filename": "^1.1.1",
+                        "y18n": "^4.0.0"
                     }
                 },
                 "call-limit": {
-                    "version": "1.1.0",
+                    "version": "1.1.1",
                     "bundled": true
                 },
                 "camelcase": {
@@ -564,24 +627,24 @@
                     "version": "2.4.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "chownr": {
-                    "version": "1.0.1",
+                    "version": "1.1.4",
                     "bundled": true
                 },
                 "ci-info": {
-                    "version": "1.4.0",
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "cidr-regex": {
-                    "version": "2.0.9",
+                    "version": "2.0.10",
                     "bundled": true,
                     "requires": {
-                        "ip-regex": "2.1.0"
+                        "ip-regex": "^2.1.0"
                     }
                 },
                 "cli-boxes": {
@@ -592,37 +655,50 @@
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^2.0.0",
+                        "strip-ansi": "^3.0.1"
                     }
                 },
                 "cli-table3": {
-                    "version": "0.5.0",
+                    "version": "0.5.1",
                     "bundled": true,
                     "requires": {
-                        "colors": "1.1.2",
-                        "object-assign": "4.1.1",
-                        "string-width": "2.1.1"
+                        "colors": "^1.1.2",
+                        "object-assign": "^4.1.0",
+                        "string-width": "^2.1.1"
                     }
                 },
                 "cliui": {
-                    "version": "4.1.0",
+                    "version": "5.0.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
-                            "version": "3.0.0",
+                            "version": "4.1.0",
                             "bundled": true
                         },
-                        "strip-ansi": {
-                            "version": "4.0.0",
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "string-width": {
+                            "version": "3.1.0",
                             "bundled": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
                             }
                         }
                     }
@@ -632,11 +708,11 @@
                     "bundled": true
                 },
                 "cmd-shim": {
-                    "version": "2.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "mkdirp": "0.5.1"
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
                     }
                 },
                 "co": {
@@ -651,7 +727,7 @@
                     "version": "1.9.1",
                     "bundled": true,
                     "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                     }
                 },
                 "color-name": {
@@ -659,7 +735,7 @@
                     "bundled": true
                 },
                 "colors": {
-                    "version": "1.1.2",
+                    "version": "1.3.3",
                     "bundled": true,
                     "optional": true
                 },
@@ -667,15 +743,15 @@
                     "version": "1.5.4",
                     "bundled": true,
                     "requires": {
-                        "strip-ansi": "3.0.1",
-                        "wcwidth": "1.0.1"
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
                     }
                 },
                 "combined-stream": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -686,30 +762,52 @@
                     "version": "1.6.2",
                     "bundled": true,
                     "requires": {
-                        "buffer-from": "1.0.0",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "config-chain": {
-                    "version": "1.1.11",
+                    "version": "1.1.12",
                     "bundled": true,
                     "requires": {
-                        "ini": "1.3.5",
-                        "proto-list": "1.2.4"
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
                     }
                 },
                 "configstore": {
-                    "version": "3.1.2",
+                    "version": "3.1.5",
                     "bundled": true,
                     "requires": {
-                        "dot-prop": "4.2.0",
-                        "graceful-fs": "4.1.11",
-                        "make-dir": "1.3.0",
-                        "unique-string": "1.0.0",
-                        "write-file-atomic": "2.3.0",
-                        "xdg-basedir": "3.0.0"
+                        "dot-prop": "^4.2.1",
+                        "graceful-fs": "^4.1.2",
+                        "make-dir": "^1.0.0",
+                        "unique-string": "^1.0.0",
+                        "write-file-atomic": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     }
                 },
                 "console-control-strings": {
@@ -720,14 +818,18 @@
                     "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "iferr": "0.1.5",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "iferr": "^0.1.5",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.0"
                     },
                     "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
                         "iferr": {
                             "version": "0.1.5",
                             "bundled": true
@@ -742,16 +844,30 @@
                     "version": "3.0.2",
                     "bundled": true,
                     "requires": {
-                        "capture-stack-trace": "1.0.0"
+                        "capture-stack-trace": "^1.0.0"
                     }
                 },
                 "cross-spawn": {
                     "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "lru-cache": {
+                            "version": "4.1.5",
+                            "bundled": true,
+                            "requires": {
+                                "pseudomap": "^1.0.2",
+                                "yallist": "^2.1.2"
+                            }
+                        },
+                        "yallist": {
+                            "version": "2.1.2",
+                            "bundled": true
+                        }
                     }
                 },
                 "crypto-random-string": {
@@ -766,7 +882,7 @@
                     "version": "1.14.1",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     }
                 },
                 "debug": {
@@ -795,14 +911,21 @@
                     "bundled": true
                 },
                 "deep-extend": {
-                    "version": "0.5.1",
+                    "version": "0.6.0",
                     "bundled": true
                 },
                 "defaults": {
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "clone": "1.0.4"
+                        "clone": "^1.0.2"
+                    }
+                },
+                "define-properties": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "requires": {
+                        "object-keys": "^1.0.12"
                     }
                 },
                 "delayed-stream": {
@@ -825,15 +948,15 @@
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "asap": "2.0.6",
-                        "wrappy": "1.0.2"
+                        "asap": "^2.0.0",
+                        "wrappy": "1"
                     }
                 },
                 "dot-prop": {
-                    "version": "4.2.0",
+                    "version": "4.2.1",
                     "bundled": true,
                     "requires": {
-                        "is-obj": "1.0.1"
+                        "is-obj": "^1.0.0"
                     }
                 },
                 "dotenv": {
@@ -848,10 +971,32 @@
                     "version": "3.6.0",
                     "bundled": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "ecc-jsbn": {
@@ -859,27 +1004,35 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1",
-                        "safer-buffer": "2.1.2"
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "editor": {
                     "version": "1.0.0",
                     "bundled": true
                 },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "bundled": true
+                },
                 "encoding": {
                     "version": "0.1.12",
                     "bundled": true,
                     "requires": {
-                        "iconv-lite": "0.4.23"
+                        "iconv-lite": "~0.4.13"
                     }
                 },
                 "end-of-stream": {
                     "version": "1.4.1",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
+                },
+                "env-paths": {
+                    "version": "2.2.0",
+                    "bundled": true
                 },
                 "err-code": {
                     "version": "1.1.2",
@@ -889,18 +1042,38 @@
                     "version": "0.1.7",
                     "bundled": true,
                     "requires": {
-                        "prr": "1.0.1"
+                        "prr": "~1.0.1"
+                    }
+                },
+                "es-abstract": {
+                    "version": "1.12.0",
+                    "bundled": true,
+                    "requires": {
+                        "es-to-primitive": "^1.1.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.1",
+                        "is-callable": "^1.1.3",
+                        "is-regex": "^1.0.4"
+                    }
+                },
+                "es-to-primitive": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "requires": {
+                        "is-callable": "^1.1.4",
+                        "is-date-object": "^1.0.1",
+                        "is-symbol": "^1.0.2"
                     }
                 },
                 "es6-promise": {
-                    "version": "4.2.4",
+                    "version": "4.2.8",
                     "bundled": true
                 },
                 "es6-promisify": {
                     "version": "5.0.0",
                     "bundled": true,
                     "requires": {
-                        "es6-promise": "4.2.4"
+                        "es6-promise": "^4.0.3"
                     }
                 },
                 "escape-string-regexp": {
@@ -911,13 +1084,19 @@
                     "version": "0.7.0",
                     "bundled": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "extend": {
@@ -937,26 +1116,41 @@
                     "bundled": true
                 },
                 "figgy-pudding": {
-                    "version": "3.4.1",
+                    "version": "3.5.1",
                     "bundled": true
                 },
                 "find-npm-prefix": {
                     "version": "1.0.2",
                     "bundled": true
                 },
-                "find-up": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "locate-path": "2.0.0"
-                    }
-                },
                 "flush-write-stream": {
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "forever-agent": {
@@ -967,48 +1161,100 @@
                     "version": "2.3.2",
                     "bundled": true,
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.19"
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "from2": {
                     "version": "2.3.0",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "fs-minipass": {
-                    "version": "1.2.5",
+                    "version": "1.2.7",
                     "bundled": true,
                     "requires": {
-                        "minipass": "2.3.3"
+                        "minipass": "^2.6.0"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "2.9.0",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        }
                     }
                 },
                 "fs-vacuum": {
                     "version": "1.2.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "path-is-inside": "1.0.2",
-                        "rimraf": "2.6.2"
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
                     }
                 },
                 "fs-write-stream-atomic": {
                     "version": "1.0.10",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "imurmurhash": "0.1.4",
-                        "readable-stream": "2.3.6"
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
                     },
                     "dependencies": {
                         "iferr": {
                             "version": "0.1.5",
                             "bundled": true
+                        },
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
                         }
                     }
                 },
@@ -1016,59 +1262,64 @@
                     "version": "1.0.0",
                     "bundled": true
                 },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2"
-                    }
+                "function-bind": {
+                    "version": "1.1.1",
+                    "bundled": true
                 },
                 "gauge": {
                     "version": "2.7.4",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     },
                     "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         }
                     }
                 },
                 "genfun": {
-                    "version": "4.0.1",
+                    "version": "5.0.0",
                     "bundled": true
                 },
                 "gentle-fs": {
-                    "version": "2.0.1",
+                    "version": "2.3.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "fs-vacuum": "1.2.10",
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "mkdirp": "0.5.1",
-                        "path-is-inside": "1.0.2",
-                        "read-cmd-shim": "1.0.1",
-                        "slide": "1.1.6"
+                        "aproba": "^1.1.2",
+                        "chownr": "^1.1.2",
+                        "cmd-shim": "^3.0.3",
+                        "fs-vacuum": "^1.2.10",
+                        "graceful-fs": "^4.1.11",
+                        "iferr": "^0.1.5",
+                        "infer-owner": "^1.0.4",
+                        "mkdirp": "^0.5.1",
+                        "path-is-inside": "^1.0.2",
+                        "read-cmd-shim": "^1.0.1",
+                        "slide": "^1.1.6"
                     },
                     "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        },
                         "iferr": {
                             "version": "0.1.5",
                             "bundled": true
@@ -1076,58 +1327,67 @@
                     }
                 },
                 "get-caller-file": {
-                    "version": "1.0.2",
+                    "version": "2.0.5",
                     "bundled": true
                 },
                 "get-stream": {
-                    "version": "3.0.0",
-                    "bundled": true
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
                 },
                 "getpass": {
                     "version": "0.1.7",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.6",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "global-dirs": {
                     "version": "0.1.1",
                     "bundled": true,
                     "requires": {
-                        "ini": "1.3.5"
+                        "ini": "^1.3.4"
                     }
                 },
                 "got": {
                     "version": "6.7.1",
                     "bundled": true,
                     "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "3.0.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.11",
+                    "version": "4.2.4",
                     "bundled": true
                 },
                 "har-schema": {
@@ -1138,12 +1398,23 @@
                     "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
+                "has": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "function-bind": "^1.1.1"
                     }
                 },
                 "has-flag": {
                     "version": "3.0.0",
+                    "bundled": true
+                },
+                "has-symbols": {
+                    "version": "1.0.0",
                     "bundled": true
                 },
                 "has-unicode": {
@@ -1151,7 +1422,7 @@
                     "bundled": true
                 },
                 "hosted-git-info": {
-                    "version": "2.7.1",
+                    "version": "2.8.8",
                     "bundled": true
                 },
                 "http-cache-semantics": {
@@ -1162,7 +1433,7 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "4.2.0",
+                        "agent-base": "4",
                         "debug": "3.1.0"
                     }
                 },
@@ -1170,31 +1441,31 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.2"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "https-proxy-agent": {
-                    "version": "2.2.1",
+                    "version": "2.2.4",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "4.2.0",
-                        "debug": "3.1.0"
+                        "agent-base": "^4.3.0",
+                        "debug": "^3.1.0"
                     }
                 },
                 "humanize-ms": {
                     "version": "1.2.1",
                     "bundled": true,
                     "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                     }
                 },
                 "iconv-lite": {
                     "version": "0.4.23",
                     "bundled": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "iferr": {
@@ -1202,10 +1473,10 @@
                     "bundled": true
                 },
                 "ignore-walk": {
-                    "version": "3.0.1",
+                    "version": "3.0.3",
                     "bundled": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "import-lazy": {
@@ -1216,16 +1487,20 @@
                     "version": "0.1.4",
                     "bundled": true
                 },
+                "infer-owner": {
+                    "version": "1.0.4",
+                    "bundled": true
+                },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
-                    "version": "2.0.3",
+                    "version": "2.0.4",
                     "bundled": true
                 },
                 "ini": {
@@ -1236,19 +1511,15 @@
                     "version": "1.10.3",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "npm-package-arg": "6.1.0",
-                        "promzard": "0.3.0",
-                        "read": "1.0.7",
-                        "read-package-json": "2.0.13",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.4",
-                        "validate-npm-package-name": "3.0.0"
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
                     }
-                },
-                "invert-kv": {
-                    "version": "1.0.0",
-                    "bundled": true
                 },
                 "ip": {
                     "version": "1.1.5",
@@ -1258,40 +1529,47 @@
                     "version": "2.1.0",
                     "bundled": true
                 },
-                "is-builtin-module": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "builtin-modules": "1.1.1"
-                    }
+                "is-callable": {
+                    "version": "1.1.4",
+                    "bundled": true
                 },
                 "is-ci": {
-                    "version": "1.1.0",
+                    "version": "1.2.1",
                     "bundled": true,
                     "requires": {
-                        "ci-info": "1.4.0"
+                        "ci-info": "^1.5.0"
+                    },
+                    "dependencies": {
+                        "ci-info": {
+                            "version": "1.6.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "is-cidr": {
-                    "version": "2.0.6",
+                    "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "cidr-regex": "2.0.9"
+                        "cidr-regex": "^2.0.10"
                     }
+                },
+                "is-date-object": {
+                    "version": "1.0.1",
+                    "bundled": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-installed-globally": {
                     "version": "0.1.0",
                     "bundled": true,
                     "requires": {
-                        "global-dirs": "0.1.1",
-                        "is-path-inside": "1.0.1"
+                        "global-dirs": "^0.1.0",
+                        "is-path-inside": "^1.0.0"
                     }
                 },
                 "is-npm": {
@@ -1306,20 +1584,34 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "path-is-inside": "1.0.2"
+                        "path-is-inside": "^1.0.1"
                     }
                 },
                 "is-redirect": {
                     "version": "1.0.0",
                     "bundled": true
                 },
+                "is-regex": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "requires": {
+                        "has": "^1.0.1"
+                    }
+                },
                 "is-retry-allowed": {
-                    "version": "1.1.0",
+                    "version": "1.2.0",
                     "bundled": true
                 },
                 "is-stream": {
                     "version": "1.1.0",
                     "bundled": true
+                },
+                "is-symbol": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "has-symbols": "^1.0.0"
+                    }
                 },
                 "is-typedarray": {
                     "version": "1.0.0",
@@ -1376,96 +1668,195 @@
                     "version": "3.1.0",
                     "bundled": true,
                     "requires": {
-                        "package-json": "4.0.1"
+                        "package-json": "^4.0.0"
                     }
                 },
                 "lazy-property": {
                     "version": "1.0.0",
                     "bundled": true
                 },
-                "lcid": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "invert-kv": "1.0.0"
-                    }
-                },
                 "libcipm": {
-                    "version": "2.0.2",
+                    "version": "4.0.8",
                     "bundled": true,
                     "requires": {
-                        "bin-links": "1.1.2",
-                        "bluebird": "3.5.1",
-                        "find-npm-prefix": "1.0.2",
-                        "graceful-fs": "4.1.11",
-                        "lock-verify": "2.0.2",
-                        "mkdirp": "0.5.1",
-                        "npm-lifecycle": "2.1.0",
-                        "npm-logical-tree": "1.2.1",
-                        "npm-package-arg": "6.1.0",
-                        "pacote": "8.1.6",
-                        "protoduck": "5.0.0",
-                        "read-package-json": "2.0.13",
-                        "rimraf": "2.6.2",
-                        "worker-farm": "1.6.0"
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.5.1",
+                        "find-npm-prefix": "^1.0.2",
+                        "graceful-fs": "^4.1.11",
+                        "ini": "^1.3.5",
+                        "lock-verify": "^2.1.0",
+                        "mkdirp": "^0.5.1",
+                        "npm-lifecycle": "^3.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "pacote": "^9.1.0",
+                        "read-package-json": "^2.0.13",
+                        "rimraf": "^2.6.2",
+                        "worker-farm": "^1.6.0"
                     }
                 },
-                "libnpmhook": {
-                    "version": "4.0.1",
+                "libnpm": {
+                    "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "figgy-pudding": "3.4.1",
-                        "npm-registry-fetch": "3.1.1"
+                        "bin-links": "^1.1.2",
+                        "bluebird": "^3.5.3",
+                        "find-npm-prefix": "^1.0.2",
+                        "libnpmaccess": "^3.0.2",
+                        "libnpmconfig": "^1.2.1",
+                        "libnpmhook": "^5.0.3",
+                        "libnpmorg": "^1.0.1",
+                        "libnpmpublish": "^1.1.2",
+                        "libnpmsearch": "^2.0.2",
+                        "libnpmteam": "^1.0.2",
+                        "lock-verify": "^2.0.2",
+                        "npm-lifecycle": "^3.0.0",
+                        "npm-logical-tree": "^1.2.1",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-profile": "^4.0.2",
+                        "npm-registry-fetch": "^4.0.0",
+                        "npmlog": "^4.1.2",
+                        "pacote": "^9.5.3",
+                        "read-package-json": "^2.0.13",
+                        "stringify-package": "^1.0.0"
+                    }
+                },
+                "libnpmaccess": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "get-stream": "^4.0.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmconfig": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1",
+                        "find-up": "^3.0.0",
+                        "ini": "^1.3.5"
                     },
                     "dependencies": {
-                        "npm-registry-fetch": {
-                            "version": "3.1.1",
+                        "find-up": {
+                            "version": "3.0.0",
                             "bundled": true,
                             "requires": {
-                                "bluebird": "3.5.1",
-                                "figgy-pudding": "3.4.1",
-                                "lru-cache": "4.1.3",
-                                "make-fetch-happen": "4.0.1",
-                                "npm-package-arg": "6.1.0"
+                                "locate-path": "^3.0.0"
                             }
+                        },
+                        "locate-path": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "2.2.0",
+                            "bundled": true
                         }
                     }
                 },
-                "libnpx": {
-                    "version": "10.2.0",
+                "libnpmhook": {
+                    "version": "5.0.3",
                     "bundled": true,
                     "requires": {
-                        "dotenv": "5.0.1",
-                        "npm-package-arg": "6.1.0",
-                        "rimraf": "2.6.2",
-                        "safe-buffer": "5.1.2",
-                        "update-notifier": "2.5.0",
-                        "which": "1.3.1",
-                        "y18n": "4.0.0",
-                        "yargs": "11.0.0"
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
-                "locate-path": {
-                    "version": "2.0.0",
+                "libnpmorg": {
+                    "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
-                "lock-verify": {
+                "libnpmpublish": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "lodash.clonedeep": "^4.5.0",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-registry-fetch": "^4.0.0",
+                        "semver": "^5.5.1",
+                        "ssri": "^6.0.1"
+                    }
+                },
+                "libnpmsearch": {
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "npm-package-arg": "6.1.0",
-                        "semver": "5.5.0"
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpmteam": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "requires": {
+                        "aproba": "^2.0.0",
+                        "figgy-pudding": "^3.4.1",
+                        "get-stream": "^4.0.0",
+                        "npm-registry-fetch": "^4.0.0"
+                    }
+                },
+                "libnpx": {
+                    "version": "10.2.4",
+                    "bundled": true,
+                    "requires": {
+                        "dotenv": "^5.0.1",
+                        "npm-package-arg": "^6.0.0",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.0",
+                        "update-notifier": "^2.3.0",
+                        "which": "^1.3.0",
+                        "y18n": "^4.0.0",
+                        "yargs": "^14.2.3"
+                    }
+                },
+                "lock-verify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "npm-package-arg": "^6.1.0",
+                        "semver": "^5.4.1"
                     }
                 },
                 "lockfile": {
                     "version": "1.0.4",
                     "bundled": true,
                     "requires": {
-                        "signal-exit": "3.0.2"
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "lodash._baseindexof": {
@@ -1476,8 +1867,8 @@
                     "version": "4.6.0",
                     "bundled": true,
                     "requires": {
-                        "lodash._createset": "4.0.3",
-                        "lodash._root": "3.0.1"
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
                     }
                 },
                 "lodash._bindcallback": {
@@ -1492,7 +1883,7 @@
                     "version": "3.1.2",
                     "bundled": true,
                     "requires": {
-                        "lodash._getnative": "3.9.1"
+                        "lodash._getnative": "^3.0.0"
                     }
                 },
                 "lodash._createset": {
@@ -1532,47 +1923,39 @@
                     "bundled": true
                 },
                 "lru-cache": {
-                    "version": "4.1.3",
+                    "version": "5.1.1",
                     "bundled": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "yallist": "^3.0.2"
                     }
                 },
                 "make-dir": {
                     "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "pify": "3.0.0"
+                        "pify": "^3.0.0"
                     }
                 },
                 "make-fetch-happen": {
-                    "version": "4.0.1",
+                    "version": "5.0.2",
                     "bundled": true,
                     "requires": {
-                        "agentkeepalive": "3.4.1",
-                        "cacache": "11.2.0",
-                        "http-cache-semantics": "3.8.1",
-                        "http-proxy-agent": "2.1.0",
-                        "https-proxy-agent": "2.2.1",
-                        "lru-cache": "4.1.3",
-                        "mississippi": "3.0.0",
-                        "node-fetch-npm": "2.0.2",
-                        "promise-retry": "1.1.1",
-                        "socks-proxy-agent": "4.0.1",
-                        "ssri": "6.0.0"
+                        "agentkeepalive": "^3.4.1",
+                        "cacache": "^12.0.0",
+                        "http-cache-semantics": "^3.8.1",
+                        "http-proxy-agent": "^2.1.0",
+                        "https-proxy-agent": "^2.2.3",
+                        "lru-cache": "^5.1.1",
+                        "mississippi": "^3.0.0",
+                        "node-fetch-npm": "^2.0.2",
+                        "promise-retry": "^1.1.1",
+                        "socks-proxy-agent": "^4.0.0",
+                        "ssri": "^6.0.0"
                     }
                 },
                 "meant": {
-                    "version": "1.0.1",
+                    "version": "1.0.2",
                     "bundled": true
-                },
-                "mem": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "mimic-fn": "1.2.0"
-                    }
                 },
                 "mime-db": {
                     "version": "1.35.0",
@@ -1582,78 +1965,82 @@
                     "version": "2.1.19",
                     "bundled": true,
                     "requires": {
-                        "mime-db": "1.35.0"
+                        "mime-db": "~1.35.0"
                     }
-                },
-                "mimic-fn": {
-                    "version": "1.2.0",
-                    "bundled": true
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
-                    "version": "0.0.8",
+                    "version": "1.2.5",
                     "bundled": true
                 },
-                "minipass": {
-                    "version": "2.3.3",
+                "minizlib": {
+                    "version": "1.3.3",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.2",
-                        "yallist": "3.0.2"
+                        "minipass": "^2.9.0"
                     },
                     "dependencies": {
-                        "yallist": {
-                            "version": "3.0.2",
-                            "bundled": true
+                        "minipass": {
+                            "version": "2.9.0",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
                         }
-                    }
-                },
-                "minizlib": {
-                    "version": "1.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "minipass": "2.3.3"
                     }
                 },
                 "mississippi": {
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.2",
-                        "duplexify": "3.6.0",
-                        "end-of-stream": "1.4.1",
-                        "flush-write-stream": "1.0.3",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "3.0.0",
-                        "pumpify": "1.5.1",
-                        "stream-each": "1.2.2",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^3.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "mkdirp": {
-                    "version": "0.5.1",
+                    "version": "0.5.5",
                     "bundled": true,
                     "requires": {
-                        "minimist": "0.0.8"
+                        "minimist": "^1.2.5"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.5",
+                            "bundled": true
+                        }
                     }
                 },
                 "move-concurrently": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "copy-concurrently": "1.0.5",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.2",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "ms": {
@@ -1668,279 +2055,156 @@
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "encoding": "0.1.12",
-                        "json-parse-better-errors": "1.0.2",
-                        "safe-buffer": "5.1.2"
+                        "encoding": "^0.1.11",
+                        "json-parse-better-errors": "^1.0.0",
+                        "safe-buffer": "^5.1.1"
                     }
                 },
                 "node-gyp": {
-                    "version": "3.8.0",
+                    "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "npmlog": "4.1.2",
-                        "osenv": "0.1.5",
-                        "request": "2.88.0",
-                        "rimraf": "2.6.2",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "which": "1.3.1"
+                        "env-paths": "^2.2.0",
+                        "glob": "^7.1.4",
+                        "graceful-fs": "^4.2.2",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.1.2",
+                        "request": "^2.88.0",
+                        "rimraf": "^2.6.3",
+                        "semver": "^5.7.1",
+                        "tar": "^4.4.12",
+                        "which": "^1.3.1"
+                    }
+                },
+                "nopt": {
+                    "version": "4.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "2.5.0",
+                    "bundled": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "resolve": "^1.10.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     },
                     "dependencies": {
-                        "nopt": {
-                            "version": "3.0.6",
+                        "resolve": {
+                            "version": "1.10.0",
                             "bundled": true,
                             "requires": {
-                                "abbrev": "1.1.1"
-                            }
-                        },
-                        "semver": {
-                            "version": "5.3.0",
-                            "bundled": true
-                        },
-                        "tar": {
-                            "version": "2.2.1",
-                            "bundled": true,
-                            "requires": {
-                                "block-stream": "0.0.9",
-                                "fstream": "1.0.11",
-                                "inherits": "2.0.3"
+                                "path-parse": "^1.0.6"
                             }
                         }
                     }
                 },
-                "nopt": {
-                    "version": "4.0.1",
-                    "bundled": true,
-                    "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
-                    }
-                },
-                "normalize-package-data": {
-                    "version": "2.4.0",
-                    "bundled": true,
-                    "requires": {
-                        "hosted-git-info": "2.7.1",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.5.0",
-                        "validate-npm-package-license": "3.0.4"
-                    }
-                },
                 "npm-audit-report": {
-                    "version": "1.3.1",
+                    "version": "1.3.3",
                     "bundled": true,
                     "requires": {
-                        "cli-table3": "0.5.0",
-                        "console-control-strings": "1.1.0"
+                        "cli-table3": "^0.5.0",
+                        "console-control-strings": "^1.1.0"
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.5",
-                    "bundled": true
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "requires": {
+                        "npm-normalize-package-bin": "^1.0.1"
+                    }
                 },
                 "npm-cache-filename": {
                     "version": "1.0.2",
                     "bundled": true
                 },
                 "npm-install-checks": {
-                    "version": "3.0.0",
+                    "version": "3.0.2",
                     "bundled": true,
                     "requires": {
-                        "semver": "5.5.0"
+                        "semver": "^2.3.0 || 3.x || 4 || 5"
                     }
                 },
                 "npm-lifecycle": {
-                    "version": "2.1.0",
+                    "version": "3.1.5",
                     "bundled": true,
                     "requires": {
-                        "byline": "5.0.0",
-                        "graceful-fs": "4.1.11",
-                        "node-gyp": "3.8.0",
-                        "resolve-from": "4.0.0",
-                        "slide": "1.1.6",
+                        "byline": "^5.0.0",
+                        "graceful-fs": "^4.1.15",
+                        "node-gyp": "^5.0.2",
+                        "resolve-from": "^4.0.0",
+                        "slide": "^1.1.6",
                         "uid-number": "0.0.6",
-                        "umask": "1.1.0",
-                        "which": "1.3.1"
+                        "umask": "^1.1.0",
+                        "which": "^1.3.1"
                     }
                 },
                 "npm-logical-tree": {
                     "version": "1.2.1",
                     "bundled": true
                 },
+                "npm-normalize-package-bin": {
+                    "version": "1.0.1",
+                    "bundled": true
+                },
                 "npm-package-arg": {
-                    "version": "6.1.0",
+                    "version": "6.1.1",
                     "bundled": true,
                     "requires": {
-                        "hosted-git-info": "2.7.1",
-                        "osenv": "0.1.5",
-                        "semver": "5.5.0",
-                        "validate-npm-package-name": "3.0.0"
+                        "hosted-git-info": "^2.7.1",
+                        "osenv": "^0.1.5",
+                        "semver": "^5.6.0",
+                        "validate-npm-package-name": "^3.0.0"
                     }
                 },
                 "npm-packlist": {
-                    "version": "1.1.11",
+                    "version": "1.4.8",
                     "bundled": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.5"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1",
+                        "npm-normalize-package-bin": "^1.0.1"
                     }
                 },
                 "npm-pick-manifest": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "npm-package-arg": "6.1.0",
-                        "semver": "5.5.0"
-                    }
-                },
-                "npm-profile": {
                     "version": "3.0.2",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "make-fetch-happen": "4.0.1"
+                        "figgy-pudding": "^3.5.1",
+                        "npm-package-arg": "^6.0.0",
+                        "semver": "^5.4.1"
                     }
                 },
-                "npm-registry-client": {
-                    "version": "8.6.0",
+                "npm-profile": {
+                    "version": "4.0.4",
                     "bundled": true,
                     "requires": {
-                        "concat-stream": "1.6.2",
-                        "graceful-fs": "4.1.11",
-                        "normalize-package-data": "2.4.0",
-                        "npm-package-arg": "6.1.0",
-                        "npmlog": "4.1.2",
-                        "once": "1.4.0",
-                        "request": "2.88.0",
-                        "retry": "0.10.1",
-                        "safe-buffer": "5.1.2",
-                        "semver": "5.5.0",
-                        "slide": "1.1.6",
-                        "ssri": "5.3.0"
-                    },
-                    "dependencies": {
-                        "retry": {
-                            "version": "0.10.1",
-                            "bundled": true
-                        },
-                        "ssri": {
-                            "version": "5.3.0",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "5.1.2"
-                            }
-                        }
+                        "aproba": "^1.1.2 || 2",
+                        "figgy-pudding": "^3.4.1",
+                        "npm-registry-fetch": "^4.0.0"
                     }
                 },
                 "npm-registry-fetch": {
-                    "version": "1.1.0",
+                    "version": "4.0.7",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "figgy-pudding": "2.0.1",
-                        "lru-cache": "4.1.3",
-                        "make-fetch-happen": "3.0.0",
-                        "npm-package-arg": "6.1.0",
-                        "safe-buffer": "5.1.2"
+                        "JSONStream": "^1.3.4",
+                        "bluebird": "^3.5.1",
+                        "figgy-pudding": "^3.4.1",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
+                        "npm-package-arg": "^6.1.0",
+                        "safe-buffer": "^5.2.0"
                     },
                     "dependencies": {
-                        "cacache": {
-                            "version": "10.0.4",
-                            "bundled": true,
-                            "requires": {
-                                "bluebird": "3.5.1",
-                                "chownr": "1.0.1",
-                                "glob": "7.1.2",
-                                "graceful-fs": "4.1.11",
-                                "lru-cache": "4.1.3",
-                                "mississippi": "2.0.0",
-                                "mkdirp": "0.5.1",
-                                "move-concurrently": "1.0.1",
-                                "promise-inflight": "1.0.1",
-                                "rimraf": "2.6.2",
-                                "ssri": "5.3.0",
-                                "unique-filename": "1.1.0",
-                                "y18n": "4.0.0"
-                            },
-                            "dependencies": {
-                                "mississippi": {
-                                    "version": "2.0.0",
-                                    "bundled": true,
-                                    "requires": {
-                                        "concat-stream": "1.6.2",
-                                        "duplexify": "3.6.0",
-                                        "end-of-stream": "1.4.1",
-                                        "flush-write-stream": "1.0.3",
-                                        "from2": "2.3.0",
-                                        "parallel-transform": "1.1.0",
-                                        "pump": "2.0.1",
-                                        "pumpify": "1.5.1",
-                                        "stream-each": "1.2.2",
-                                        "through2": "2.0.3"
-                                    }
-                                }
-                            }
-                        },
-                        "figgy-pudding": {
-                            "version": "2.0.1",
+                        "safe-buffer": {
+                            "version": "5.2.1",
                             "bundled": true
-                        },
-                        "make-fetch-happen": {
-                            "version": "3.0.0",
-                            "bundled": true,
-                            "requires": {
-                                "agentkeepalive": "3.4.1",
-                                "cacache": "10.0.4",
-                                "http-cache-semantics": "3.8.1",
-                                "http-proxy-agent": "2.1.0",
-                                "https-proxy-agent": "2.2.1",
-                                "lru-cache": "4.1.3",
-                                "mississippi": "3.0.0",
-                                "node-fetch-npm": "2.0.2",
-                                "promise-retry": "1.1.1",
-                                "socks-proxy-agent": "3.0.1",
-                                "ssri": "5.3.0"
-                            }
-                        },
-                        "pump": {
-                            "version": "2.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
-                            }
-                        },
-                        "smart-buffer": {
-                            "version": "1.1.15",
-                            "bundled": true
-                        },
-                        "socks": {
-                            "version": "1.1.10",
-                            "bundled": true,
-                            "requires": {
-                                "ip": "1.1.5",
-                                "smart-buffer": "1.1.15"
-                            }
-                        },
-                        "socks-proxy-agent": {
-                            "version": "3.0.1",
-                            "bundled": true,
-                            "requires": {
-                                "agent-base": "4.2.0",
-                                "socks": "1.1.10"
-                            }
-                        },
-                        "ssri": {
-                            "version": "5.3.0",
-                            "bundled": true,
-                            "requires": {
-                                "safe-buffer": "5.1.2"
-                            }
                         }
                     }
                 },
@@ -1948,7 +2212,7 @@
                     "version": "2.0.2",
                     "bundled": true,
                     "requires": {
-                        "path-key": "2.0.1"
+                        "path-key": "^2.0.0"
                     }
                 },
                 "npm-user-validate": {
@@ -1959,10 +2223,10 @@
                     "version": "4.1.2",
                     "bundled": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -1977,29 +2241,32 @@
                     "version": "4.1.1",
                     "bundled": true
                 },
+                "object-keys": {
+                    "version": "1.0.12",
+                    "bundled": true
+                },
+                "object.getownpropertydescriptors": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "requires": {
+                        "define-properties": "^1.1.2",
+                        "es-abstract": "^1.5.1"
+                    }
+                },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "opener": {
-                    "version": "1.5.0",
+                    "version": "1.5.1",
                     "bundled": true
                 },
                 "os-homedir": {
                     "version": "1.0.2",
                     "bundled": true
-                },
-                "os-locale": {
-                    "version": "2.1.0",
-                    "bundled": true,
-                    "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
-                    }
                 },
                 "os-tmpdir": {
                     "version": "1.0.2",
@@ -2009,29 +2276,11 @@
                     "version": "0.1.5",
                     "bundled": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "p-finally": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "p-limit": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "p-try": "1.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "p-limit": "1.2.0"
-                    }
-                },
-                "p-try": {
                     "version": "1.0.0",
                     "bundled": true
                 },
@@ -2039,50 +2288,87 @@
                     "version": "4.0.1",
                     "bundled": true,
                     "requires": {
-                        "got": "6.7.1",
-                        "registry-auth-token": "3.3.2",
-                        "registry-url": "3.1.0",
-                        "semver": "5.5.0"
+                        "got": "^6.7.1",
+                        "registry-auth-token": "^3.0.1",
+                        "registry-url": "^3.0.3",
+                        "semver": "^5.1.0"
                     }
                 },
                 "pacote": {
-                    "version": "8.1.6",
+                    "version": "9.5.12",
                     "bundled": true,
                     "requires": {
-                        "bluebird": "3.5.1",
-                        "cacache": "11.2.0",
-                        "get-stream": "3.0.0",
-                        "glob": "7.1.2",
-                        "lru-cache": "4.1.3",
-                        "make-fetch-happen": "4.0.1",
-                        "minimatch": "3.0.4",
-                        "minipass": "2.3.3",
-                        "mississippi": "3.0.0",
-                        "mkdirp": "0.5.1",
-                        "normalize-package-data": "2.4.0",
-                        "npm-package-arg": "6.1.0",
-                        "npm-packlist": "1.1.11",
-                        "npm-pick-manifest": "2.1.0",
-                        "osenv": "0.1.5",
-                        "promise-inflight": "1.0.1",
-                        "promise-retry": "1.1.1",
-                        "protoduck": "5.0.0",
-                        "rimraf": "2.6.2",
-                        "safe-buffer": "5.1.2",
-                        "semver": "5.5.0",
-                        "ssri": "6.0.0",
-                        "tar": "4.4.6",
-                        "unique-filename": "1.1.0",
-                        "which": "1.3.1"
+                        "bluebird": "^3.5.3",
+                        "cacache": "^12.0.2",
+                        "chownr": "^1.1.2",
+                        "figgy-pudding": "^3.5.1",
+                        "get-stream": "^4.1.0",
+                        "glob": "^7.1.3",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^5.1.1",
+                        "make-fetch-happen": "^5.0.0",
+                        "minimatch": "^3.0.4",
+                        "minipass": "^2.3.5",
+                        "mississippi": "^3.0.0",
+                        "mkdirp": "^0.5.1",
+                        "normalize-package-data": "^2.4.0",
+                        "npm-normalize-package-bin": "^1.0.0",
+                        "npm-package-arg": "^6.1.0",
+                        "npm-packlist": "^1.1.12",
+                        "npm-pick-manifest": "^3.0.0",
+                        "npm-registry-fetch": "^4.0.0",
+                        "osenv": "^0.1.5",
+                        "promise-inflight": "^1.0.1",
+                        "promise-retry": "^1.1.1",
+                        "protoduck": "^5.0.1",
+                        "rimraf": "^2.6.2",
+                        "safe-buffer": "^5.1.2",
+                        "semver": "^5.6.0",
+                        "ssri": "^6.0.1",
+                        "tar": "^4.4.10",
+                        "unique-filename": "^1.1.1",
+                        "which": "^1.3.1"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "2.9.0",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
+                        }
                     }
                 },
                 "parallel-transform": {
                     "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "path-exists": {
@@ -2099,6 +2385,10 @@
                 },
                 "path-key": {
                     "version": "2.0.1",
+                    "bundled": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
                     "bundled": true
                 },
                 "performance-now": {
@@ -2125,8 +2415,8 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "err-code": "1.1.2",
-                        "retry": "0.10.1"
+                        "err-code": "^1.0.0",
+                        "retry": "^0.10.0"
                     },
                     "dependencies": {
                         "retry": {
@@ -2139,7 +2429,7 @@
                     "version": "0.3.0",
                     "bundled": true,
                     "requires": {
-                        "read": "1.0.7"
+                        "read": "1"
                     }
                 },
                 "proto-list": {
@@ -2147,10 +2437,10 @@
                     "bundled": true
                 },
                 "protoduck": {
-                    "version": "5.0.0",
+                    "version": "5.0.1",
                     "bundled": true,
                     "requires": {
-                        "genfun": "4.0.1"
+                        "genfun": "^5.0.0"
                     }
                 },
                 "prr": {
@@ -2169,25 +2459,25 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                     }
                 },
                 "pumpify": {
                     "version": "1.5.1",
                     "bundled": true,
                     "requires": {
-                        "duplexify": "3.6.0",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.6.0",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                     },
                     "dependencies": {
                         "pump": {
                             "version": "2.0.1",
                             "bundled": true,
                             "requires": {
-                                "end-of-stream": "1.4.1",
-                                "once": "1.4.0"
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
                             }
                         }
                     }
@@ -2205,11 +2495,12 @@
                     "bundled": true
                 },
                 "query-string": {
-                    "version": "6.1.0",
+                    "version": "6.8.2",
                     "bundled": true,
                     "requires": {
-                        "decode-uri-component": "0.2.0",
-                        "strict-uri-encode": "2.0.0"
+                        "decode-uri-component": "^0.2.0",
+                        "split-on-first": "^1.0.0",
+                        "strict-uri-encode": "^2.0.0"
                     }
                 },
                 "qw": {
@@ -2217,132 +2508,120 @@
                     "bundled": true
                 },
                 "rc": {
-                    "version": "1.2.7",
+                    "version": "1.2.8",
                     "bundled": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true
-                        }
+                        "deep-extend": "^0.6.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     }
                 },
                 "read": {
                     "version": "1.0.7",
                     "bundled": true,
                     "requires": {
-                        "mute-stream": "0.0.7"
+                        "mute-stream": "~0.0.4"
                     }
                 },
                 "read-cmd-shim": {
-                    "version": "1.0.1",
+                    "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "read-installed": {
                     "version": "4.0.3",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "graceful-fs": "4.1.11",
-                        "read-package-json": "2.0.13",
-                        "readdir-scoped-modules": "1.0.2",
-                        "semver": "5.5.0",
-                        "slide": "1.1.6",
-                        "util-extend": "1.0.3"
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
                     }
                 },
                 "read-package-json": {
-                    "version": "2.0.13",
+                    "version": "2.1.1",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "graceful-fs": "4.1.11",
-                        "json-parse-better-errors": "1.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "slash": "1.0.0"
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-better-errors": "^1.0.1",
+                        "normalize-package-data": "^2.0.0",
+                        "npm-normalize-package-bin": "^1.0.0"
                     }
                 },
                 "read-package-tree": {
-                    "version": "5.2.1",
+                    "version": "5.3.1",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "once": "1.4.0",
-                        "read-package-json": "2.0.13",
-                        "readdir-scoped-modules": "1.0.2"
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "util-promisify": "^2.1.0"
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
+                    "version": "3.6.0",
                     "bundled": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
                     }
                 },
                 "readdir-scoped-modules": {
-                    "version": "1.0.2",
+                    "version": "1.1.0",
                     "bundled": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "graceful-fs": "4.1.11",
-                        "once": "1.4.0"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
                     }
                 },
                 "registry-auth-token": {
-                    "version": "3.3.2",
+                    "version": "3.4.0",
                     "bundled": true,
                     "requires": {
-                        "rc": "1.2.7",
-                        "safe-buffer": "5.1.2"
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "registry-url": {
                     "version": "3.1.0",
                     "bundled": true,
                     "requires": {
-                        "rc": "1.2.7"
+                        "rc": "^1.0.1"
                     }
                 },
                 "request": {
                     "version": "2.88.0",
                     "bundled": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.1.0",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
-                        "oauth-sign": "0.9.0",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "tough-cookie": "2.4.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "require-directory": {
@@ -2350,7 +2629,7 @@
                     "bundled": true
                 },
                 "require-main-filename": {
-                    "version": "1.0.1",
+                    "version": "2.0.0",
                     "bundled": true
                 },
                 "resolve-from": {
@@ -2362,17 +2641,23 @@
                     "bundled": true
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.7.1",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.1.3"
                     }
                 },
                 "run-queue": {
                     "version": "1.0.3",
                     "bundled": true,
                     "requires": {
-                        "aproba": "1.2.0"
+                        "aproba": "^1.1.1"
+                    },
+                    "dependencies": {
+                        "aproba": {
+                            "version": "1.2.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "safe-buffer": {
@@ -2384,14 +2669,14 @@
                     "bundled": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.7.1",
                     "bundled": true
                 },
                 "semver-diff": {
                     "version": "2.1.0",
                     "bundled": true,
                     "requires": {
-                        "semver": "5.5.0"
+                        "semver": "^5.0.3"
                     }
                 },
                 "set-blocking": {
@@ -2399,18 +2684,17 @@
                     "bundled": true
                 },
                 "sha": {
-                    "version": "2.0.1",
+                    "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "readable-stream": "2.3.6"
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "shebang-command": {
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "shebang-regex": "1.0.0"
+                        "shebang-regex": "^1.0.0"
                     }
                 },
                 "shebang-regex": {
@@ -2421,32 +2705,37 @@
                     "version": "3.0.2",
                     "bundled": true
                 },
-                "slash": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
                 "slide": {
                     "version": "1.1.6",
                     "bundled": true
                 },
                 "smart-buffer": {
-                    "version": "4.0.1",
+                    "version": "4.1.0",
                     "bundled": true
                 },
                 "socks": {
-                    "version": "2.2.0",
+                    "version": "2.3.3",
                     "bundled": true,
                     "requires": {
                         "ip": "1.1.5",
-                        "smart-buffer": "4.0.1"
+                        "smart-buffer": "^4.1.0"
                     }
                 },
                 "socks-proxy-agent": {
-                    "version": "4.0.1",
+                    "version": "4.0.2",
                     "bundled": true,
                     "requires": {
-                        "agent-base": "4.2.0",
-                        "socks": "2.2.0"
+                        "agent-base": "~4.2.1",
+                        "socks": "~2.3.2"
+                    },
+                    "dependencies": {
+                        "agent-base": {
+                            "version": "4.2.1",
+                            "bundled": true,
+                            "requires": {
+                                "es6-promisify": "^5.0.0"
+                            }
+                        }
                     }
                 },
                 "sorted-object": {
@@ -2457,16 +2746,16 @@
                     "version": "2.1.3",
                     "bundled": true,
                     "requires": {
-                        "from2": "1.3.0",
-                        "stream-iterate": "1.2.0"
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
                     },
                     "dependencies": {
                         "from2": {
                             "version": "1.3.0",
                             "bundled": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "1.1.14"
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
                             }
                         },
                         "isarray": {
@@ -2477,10 +2766,10 @@
                             "version": "1.1.14",
                             "bundled": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "string_decoder": {
@@ -2493,8 +2782,8 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "spdx-expression-parse": "3.0.0",
-                        "spdx-license-ids": "3.0.0"
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
                     }
                 },
                 "spdx-exceptions": {
@@ -2505,47 +2794,76 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "spdx-exceptions": "2.1.0",
-                        "spdx-license-ids": "3.0.0"
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
                     }
                 },
                 "spdx-license-ids": {
-                    "version": "3.0.0",
+                    "version": "3.0.5",
+                    "bundled": true
+                },
+                "split-on-first": {
+                    "version": "1.1.0",
                     "bundled": true
                 },
                 "sshpk": {
                     "version": "1.14.2",
                     "bundled": true,
                     "requires": {
-                        "asn1": "0.2.4",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.2",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.2",
-                        "getpass": "0.1.7",
-                        "jsbn": "0.1.1",
-                        "safer-buffer": "2.1.2",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jsbn": "~0.1.0",
+                        "safer-buffer": "^2.0.2",
+                        "tweetnacl": "~0.14.0"
                     }
                 },
                 "ssri": {
-                    "version": "6.0.0",
-                    "bundled": true
+                    "version": "6.0.1",
+                    "bundled": true,
+                    "requires": {
+                        "figgy-pudding": "^3.5.1"
+                    }
                 },
                 "stream-each": {
                     "version": "1.2.2",
                     "bundled": true,
                     "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                     }
                 },
                 "stream-iterate": {
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "readable-stream": "^2.1.5",
+                        "stream-shift": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "stream-shift": {
@@ -2560,8 +2878,8 @@
                     "version": "2.1.1",
                     "bundled": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "ansi-regex": {
@@ -2576,27 +2894,33 @@
                             "version": "4.0.0",
                             "bundled": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
                 },
                 "string_decoder": {
-                    "version": "1.1.1",
+                    "version": "1.3.0",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.2.0"
+                    },
+                    "dependencies": {
+                        "safe-buffer": {
+                            "version": "5.2.0",
+                            "bundled": true
+                        }
                     }
                 },
                 "stringify-package": {
-                    "version": "1.0.0",
+                    "version": "1.0.1",
                     "bundled": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-eof": {
@@ -2611,25 +2935,29 @@
                     "version": "5.4.0",
                     "bundled": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "tar": {
-                    "version": "4.4.6",
+                    "version": "4.4.13",
                     "bundled": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.3.3",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.2",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.1.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.8.6",
+                        "minizlib": "^1.2.1",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.3"
                     },
                     "dependencies": {
-                        "yallist": {
-                            "version": "3.0.2",
-                            "bundled": true
+                        "minipass": {
+                            "version": "2.9.0",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "^5.1.2",
+                                "yallist": "^3.0.0"
+                            }
                         }
                     }
                 },
@@ -2637,7 +2965,7 @@
                     "version": "1.2.0",
                     "bundled": true,
                     "requires": {
-                        "execa": "0.7.0"
+                        "execa": "^0.7.0"
                     }
                 },
                 "text-table": {
@@ -2652,8 +2980,30 @@
                     "version": "2.0.3",
                     "bundled": true,
                     "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.6",
+                            "bundled": true,
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        },
+                        "string_decoder": {
+                            "version": "1.1.1",
+                            "bundled": true,
+                            "requires": {
+                                "safe-buffer": "~5.1.0"
+                            }
+                        }
                     }
                 },
                 "timed-out": {
@@ -2668,15 +3018,15 @@
                     "version": "2.4.3",
                     "bundled": true,
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -2697,24 +3047,24 @@
                     "bundled": true
                 },
                 "unique-filename": {
-                    "version": "1.1.0",
+                    "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "unique-slug": "2.0.0"
+                        "unique-slug": "^2.0.0"
                     }
                 },
                 "unique-slug": {
                     "version": "2.0.0",
                     "bundled": true,
                     "requires": {
-                        "imurmurhash": "0.1.4"
+                        "imurmurhash": "^0.1.4"
                     }
                 },
                 "unique-string": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "crypto-random-string": "1.0.0"
+                        "crypto-random-string": "^1.0.0"
                     }
                 },
                 "unpipe": {
@@ -2729,23 +3079,23 @@
                     "version": "2.5.0",
                     "bundled": true,
                     "requires": {
-                        "boxen": "1.3.0",
-                        "chalk": "2.4.1",
-                        "configstore": "3.1.2",
-                        "import-lazy": "2.1.0",
-                        "is-ci": "1.1.0",
-                        "is-installed-globally": "0.1.0",
-                        "is-npm": "1.0.0",
-                        "latest-version": "3.1.0",
-                        "semver-diff": "2.1.0",
-                        "xdg-basedir": "3.0.0"
+                        "boxen": "^1.2.1",
+                        "chalk": "^2.0.1",
+                        "configstore": "^3.0.0",
+                        "import-lazy": "^2.1.0",
+                        "is-ci": "^1.0.10",
+                        "is-installed-globally": "^0.1.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     }
                 },
                 "url-parse-lax": {
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "prepend-http": "1.0.4"
+                        "prepend-http": "^1.0.1"
                     }
                 },
                 "util-deprecate": {
@@ -2756,46 +3106,53 @@
                     "version": "1.0.3",
                     "bundled": true
                 },
+                "util-promisify": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "object.getownpropertydescriptors": "^2.0.3"
+                    }
+                },
                 "uuid": {
-                    "version": "3.3.2",
+                    "version": "3.3.3",
                     "bundled": true
                 },
                 "validate-npm-package-license": {
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "spdx-correct": "3.0.0",
-                        "spdx-expression-parse": "3.0.0"
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
                     }
                 },
                 "validate-npm-package-name": {
                     "version": "3.0.0",
                     "bundled": true,
                     "requires": {
-                        "builtins": "1.0.3"
+                        "builtins": "^1.0.3"
                     }
                 },
                 "verror": {
                     "version": "1.10.0",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                     }
                 },
                 "wcwidth": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "defaults": "1.0.3"
+                        "defaults": "^1.0.3"
                     }
                 },
                 "which": {
                     "version": "1.3.1",
                     "bundled": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 },
                 "which-module": {
@@ -2806,49 +3163,65 @@
                     "version": "1.1.2",
                     "bundled": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     },
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         }
                     }
                 },
                 "widest-line": {
-                    "version": "2.0.0",
+                    "version": "2.0.1",
                     "bundled": true,
                     "requires": {
-                        "string-width": "2.1.1"
+                        "string-width": "^2.1.1"
                     }
                 },
                 "worker-farm": {
-                    "version": "1.6.0",
+                    "version": "1.7.0",
                     "bundled": true,
                     "requires": {
-                        "errno": "0.1.7"
+                        "errno": "~0.1.7"
                     }
                 },
                 "wrap-ansi": {
-                    "version": "2.1.0",
+                    "version": "5.1.0",
                     "bundled": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
                     },
                     "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
                         "string-width": {
-                            "version": "1.0.2",
+                            "version": "3.1.0",
                             "bundled": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
                             }
                         }
                     }
@@ -2858,12 +3231,12 @@
                     "bundled": true
                 },
                 "write-file-atomic": {
-                    "version": "2.3.0",
+                    "version": "2.4.3",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "signal-exit": "3.0.2"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "xdg-basedir": {
@@ -2879,38 +3252,97 @@
                     "bundled": true
                 },
                 "yallist": {
-                    "version": "2.1.2",
+                    "version": "3.0.3",
                     "bundled": true
                 },
                 "yargs": {
-                    "version": "11.0.0",
+                    "version": "14.2.3",
                     "bundled": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^5.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^15.0.1"
                     },
                     "dependencies": {
-                        "y18n": {
-                            "version": "3.2.1",
+                        "ansi-regex": {
+                            "version": "4.1.0",
                             "bundled": true
+                        },
+                        "find-up": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "locate-path": "^3.0.0"
+                            }
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "bundled": true
+                        },
+                        "locate-path": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-locate": "^3.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "2.3.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-try": "^2.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "requires": {
+                                "p-limit": "^2.0.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "2.2.0",
+                            "bundled": true
+                        },
+                        "string-width": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "requires": {
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "bundled": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
                         }
                     }
                 },
                 "yargs-parser": {
-                    "version": "9.0.2",
+                    "version": "15.0.1",
                     "bundled": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "5.3.1",
+                            "bundled": true
+                        }
                     }
                 }
             }
@@ -2920,13 +3352,8 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
-        },
-        "package": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package/-/package-1.0.1.tgz",
-            "integrity": "sha1-0lofmeJQbcsn1nBLg9yooxLk7cw="
         },
         "path-is-absolute": {
             "version": "1.0.1",
@@ -2934,9 +3361,9 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "q": {
             "version": "1.5.1",
@@ -2944,30 +3371,29 @@
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "readable-stream": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
             }
         },
-        "remove-trailing-separator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+        "readdir-glob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.0.0.tgz",
+            "integrity": "sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==",
+            "requires": {
+                "minimatch": "^3.0.4"
+            }
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.1.3"
             }
         },
         "safe-buffer": {
@@ -2980,35 +3406,25 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "tar-stream": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
+            "integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
             "requires": {
-                "bl": "1.2.2",
-                "buffer-alloc": "1.1.0",
-                "end-of-stream": "1.4.1",
-                "fs-constants": "1.0.0",
-                "readable-stream": "2.3.6",
-                "to-buffer": "1.1.1",
-                "xtend": "4.0.1"
+                "bl": "^4.0.1",
+                "end-of-stream": "^1.4.1",
+                "fs-constants": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1"
             }
         },
         "temporary": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/temporary/-/temporary-0.0.8.tgz",
-            "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
-            "requires": {
-                "package": "1.0.1"
-            }
-        },
-        "to-buffer": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/temporary/-/temporary-1.1.0.tgz",
+            "integrity": "sha512-geB3U/E75RLr++koy9EBw4mZ1BCfxg72SYJQdQld1iRvka+fyijfbiXrVpWQB9bJKNsgAB4lIHOeJtVSvyiJiQ=="
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -3020,20 +3436,14 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
-        "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        },
         "zip-stream": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-            "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
+            "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.10",
-                "readable-stream": "2.3.6"
+                "archiver-utils": "^2.1.0",
+                "compress-commons": "^4.0.0",
+                "readable-stream": "^3.6.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
         }
     ],
     "dependencies": {
-        "temporary": "^0.0.8",
-        "archiver": "^2.1.1",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.6.2",
-        "npm": "^6.4.1",
-        "q": "^1.5.1"
+        "archiver": "^5.0.0",
+        "mkdirp": "^1.0.4",
+        "npm": "^6.14.8",
+        "q": "^1.5.1",
+        "rimraf": "^3.0.2",
+        "temporary": "^1.1.0"
     },
     "keywords": [
         "gruntplugin"


### PR DESCRIPTION
I ran a quick update since dependabot was warning about this lib. I have not really tested properly, just applied the updates.

```bash
grunt-aws-lambda-package master = $ npm audit 
found 98 vulnerabilities (72 low, 26 high) in 433 scanned packages
  run `npm audit fix` to fix 75 of them.
  1 vulnerability requires semver-major dependency updates.
  22 vulnerabilities require manual review. See the full report for details.

grunt-aws-lambda-package master = $ npm audit fix
npm WARN grunt-aws-lambda-package@0.0.6 No license field.

+ npm@6.14.8
added 483 packages from 899 contributors in 27.507s

2 packages are looking for funding
  run `npm fund` for details

fixed 75 of 98 vulnerabilities in 433 scanned packages
  22 vulnerabilities required manual review and could not be updated
  1 package update for 1 vulnerability involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or refer to `npm audit` for steps to fix these manually)

grunt-aws-lambda-package master * = $ npm-upgrade check
Checking for outdated dependencies for "C:\Dev\Github\grunt-aws-lambda-package\package.json"...
[====================] 6/6 100%

New versions of active modules available:

  archiver    ^2.1.1   ?   ^5.0.0
  mkdirp      ^0.5.1   ?   ^1.0.4
  rimraf      ^2.6.2   ?   ^3.0.2
  temporary   ^0.0.8   ?   ^1.1.0

? Update "archiver" in package.json from ^2.1.1 to ^5.0.0? Yes

? Update "mkdirp" in package.json from ^0.5.1 to ^1.0.4? Yes

? Update "rimraf" in package.json from ^2.6.2 to ^3.0.2? Yes

? Update "temporary" in package.json from ^0.0.8 to ^1.1.0? Yes


These packages will be updated:

  archiver    ^2.1.1   ?   ^5.0.0 
  mkdirp      ^0.5.1   ?   ^1.0.4
  rimraf      ^2.6.2   ?   ^3.0.2
  temporary   ^0.0.8   ?   ^1.1.0

? Update package.json? Yes

grunt-aws-lambda-package master * = $ npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 482 scanned packages
grunt-aws-lambda-package master = $ 

```


